### PR TITLE
fixing resize window

### DIFF
--- a/src/components/ui/TableRows.tsx
+++ b/src/components/ui/TableRows.tsx
@@ -8,7 +8,7 @@ import { IEvents, IDates } from '@/types';
 const TableRows = ({ _id, date, title, description, location, start_stack, game_type, blind_levels }: IEvents) => {
     const router = useRouter();
 
-    const [windowsWidth, setWindows] = useState(0);
+    const [windowsWidth, setWindows] = useState(window.innerWidth);
 
     useEffect(() => {
         const handleResize = () => {
@@ -17,7 +17,7 @@ const TableRows = ({ _id, date, title, description, location, start_stack, game_
 
         window.addEventListener('resize', handleResize);
         return () => window.removeEventListener('resize', handleResize);
-    }, [windowsWidth])
+    }, [])
 
     const midScreen = 830;
 

--- a/src/components/ui/TableSchedule.tsx
+++ b/src/components/ui/TableSchedule.tsx
@@ -4,7 +4,7 @@ import { TableHead, TableRow } from "@/components/ui/table";
 
 const TableSchedule = () => {
 
-    const [windowsWidth, setWindows] = useState(0);
+    const [windowsWidth, setWindows] = useState(window.innerWidth);
 
     useEffect(() => {
         const handleResize = () => {
@@ -13,8 +13,8 @@ const TableSchedule = () => {
 
         window.addEventListener('resize', handleResize);
         return () => window.removeEventListener('resize', handleResize);
-    }, [windowsWidth])
-    console.log(windowsWidth)
+    }, [])
+
     const midScreen = 830;
 
     return (

--- a/src/components/ui/menu.tsx
+++ b/src/components/ui/menu.tsx
@@ -30,7 +30,7 @@ const NavLinks = ({ classes, menuExp, setMenuExpanded, closeMenu }: Classes & { 
 };
 
 const MobileNav = ({ menuExp, setMenuExpanded, closeMenu }: MenuExp & { closeMenu: () => void }) => {
-  const [windowsWidth, setWindows] = useState(0);
+  const [windowsWidth, setWindows] = useState(window.innerWidth);
 
     useEffect(() => {
         const handleResize = () => {


### PR DESCRIPTION
Fixing resize window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved initial rendering of components by setting `windowsWidth` state to `window.innerWidth` instead of `0`, ensuring accurate initial width measurement.
  - Updated `useEffect` hooks to avoid unnecessary re-renders by removing `windowsWidth` from dependency arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->