### PR TITLE
fixing btc col width

### DIFF
--- a/src/app/schedule/[slug]/page.tsx
+++ b/src/app/schedule/[slug]/page.tsx
@@ -62,7 +62,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
 					<TableRow className="border-x-2 border-y-2">
 						<TableHead className="w-[350px] border-x-2">Name</TableHead>
 						<TableHead className="w-[350px] border-x-2">BTC Address</TableHead>
-						<TableHead className="border-x-2">BTC</TableHead>
+						<TableHead className="w-[100px] border-x-2">BTC</TableHead>
 						<TableHead className="w-[180px] text-center">Tx</TableHead>
 					</TableRow>
 				</TableHeader>


### PR DESCRIPTION
Fix: https://github.com/bitcoinbrisbane/bitcoinpokertour/issues/68

![image](https://github.com/bitcoinbrisbane/bitcoinpokertour/assets/34518489/1c8b08f4-7720-4c47-adb7-150953cfd128)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the width of the BTC column in the schedule table to improve layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->